### PR TITLE
Allow base64 strict encoding to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ end
 # Custom ID attribute
 signed_document = Xmldsig::SignedDocument.new(signed_xml, id_attr: "MyID")
 signed_document.validate(certificate)
+
+# Specify Base64 Strict Encoding of Signature Value and Digest Value
+unsigned_document = Xmldsig::SignedDocument.new(unsigned_xml, base64_strict_encode: true)
+signed_xml = unsigned_document.sign(private_key)
 ```
 
 ## Known issues

--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -5,11 +5,12 @@ module Xmldsig
     class ReferencedNodeNotFound < Exception;
     end
 
-    def initialize(reference, id_attr = nil, referenced_documents = {})
+    def initialize(reference, id_attr = nil, referenced_documents = {}, base64_strict_encode = false)
       @reference = reference
       @errors    = []
       @id_attr = id_attr
       @referenced_documents = referenced_documents
+      @base64_strict_encode = base64_strict_encode
     end
 
     def document
@@ -83,8 +84,8 @@ module Xmldsig
     end
 
     def digest_value=(digest_value)
-      reference.at_xpath("descendant::ds:DigestValue", NAMESPACES).content =
-          Base64.strict_encode64(digest_value).chomp
+      encoded_value = (@base64_strict_encode == true) ? Base64.strict_encode64(digest_value) : Base64.encode64(digest_value)
+      reference.at_xpath("descendant::ds:DigestValue", NAMESPACES).content = encoded_value.chomp
     end
 
     def transforms

--- a/lib/xmldsig/signature.rb
+++ b/lib/xmldsig/signature.rb
@@ -2,15 +2,16 @@ module Xmldsig
   class Signature
     attr_accessor :signature
 
-    def initialize(signature, id_attr = nil, referenced_documents = {})
+    def initialize(signature, id_attr = nil, referenced_documents = {}, base64_strict_encode = false)
       @signature = signature
       @id_attr = id_attr
       @referenced_documents = referenced_documents
+      @base64_strict_encode = base64_strict_encode
     end
 
     def references
       @references ||= signature.xpath("descendant::ds:Reference", NAMESPACES).map do |node|
-        Reference.new(node, @id_attr, @referenced_documents)
+        Reference.new(node, @id_attr, @referenced_documents, @base64_strict_encode)
       end
     end
 
@@ -98,8 +99,8 @@ module Xmldsig
     end
 
     def signature_value=(signature_value)
-      signature.at_xpath("descendant::ds:SignatureValue", NAMESPACES).content =
-          Base64.strict_encode64(signature_value).chomp
+      encoded_value = (@base64_strict_encode == true) ? Base64.strict_encode64(signature_value) : Base64.encode64(signature_value)
+      signature.at_xpath("descendant::ds:SignatureValue", NAMESPACES).content = encoded_value.chomp
     end
 
     def validate_schema(schema)

--- a/lib/xmldsig/signed_document.rb
+++ b/lib/xmldsig/signed_document.rb
@@ -1,6 +1,6 @@
 module Xmldsig
   class SignedDocument
-    attr_accessor :document, :id_attr, :force, :referenced_documents
+    attr_accessor :document, :id_attr, :force, :referenced_documents, :base64_strict_encode
 
     def initialize(document, options = {})
       @document = if document.kind_of?(Nokogiri::XML::Document)
@@ -11,6 +11,7 @@ module Xmldsig
       @id_attr  = options[:id_attr] if options[:id_attr]
       @force    = options[:force]
       @referenced_documents = options.fetch(:referenced_documents, {})
+      @base64_strict_encode = options[:base64_strict_encode]
     end
 
     def validate(certificate = nil, schema = nil, &block)
@@ -36,7 +37,7 @@ module Xmldsig
     def signatures
       document.xpath("//ds:Signature", NAMESPACES).
           sort { |left, right| left.ancestors.size <=> right.ancestors.size }.
-          collect { |node| Signature.new(node, @id_attr, referenced_documents) } || []
+          collect { |node| Signature.new(node, @id_attr, referenced_documents, @base64_strict_encode) } || []
     end
   end
 end

--- a/spec/fixtures/signed_with_base64_strict_encode_on.xml
+++ b/spec/fixtures/signed_with_base64_strict_encode_on.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="foo">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>ftoSYFdze1AWgGHF5N9i9SFKThXkqH2AdyzA3/epbJw=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>E3yyqsSoxRkhYEuaEtR+SLg85gU5B4a7xUXA+d2Zn6j7F6z73dOd8iYHOusBTy3C/3ujbmPhHKg8uX9kUE8b+YoOqZt4z9pdxAq44nJEuijwi4doIPpHWirvBnSoP5IoL0DYzGVrgj8udRzfAw5nNeV7wSrBZEn+yrxmUPJoUZc=</ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig/reference_spec.rb
+++ b/spec/lib/xmldsig/reference_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Xmldsig::Reference do
   let(:document) { Nokogiri::XML::Document.parse File.read("spec/fixtures/signed.xml") }
   let(:reference) { Xmldsig::Reference.new(document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES)) }
+  let(:reference_with_strict_encoding) { Xmldsig::Reference.new(document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES), id_attr = nil, referenced_documents = {}, base64_strict_encode: true) }
 
   describe "#digest_value" do
     it "returns the digest value in the xml" do
@@ -22,6 +23,20 @@ describe Xmldsig::Reference do
     it "sets the correct digest value" do
       reference.sign
       expect(reference.digest_value).to eq(Base64.decode64("ftoSYFdze1AWgGHF5N9i9SFKThXkqH2AdyzA3/epbJw="))
+    end
+
+    it "sets the correct digest value when base64 strict encoding is enabled" do
+      reference.sign
+      expect(reference.digest_value).to eq(Base64.decode64("ftoSYFdze1AWgGHF5N9i9SFKThXkqH2AdyzA3/epbJw="))
+    end
+  end
+
+  describe "#sign" do
+    let(:document) { Nokogiri::XML::Document.parse File.read("spec/fixtures/unsigned.xml") }
+
+    it "sets the correct digest value when base64 strict encoding is enabled" do
+      reference_with_strict_encoding.sign
+      expect(reference_with_strict_encoding.digest_value).to eq(Base64.decode64("ftoSYFdze1AWgGHF5N9i9SFKThXkqH2AdyzA3/epbJw="))
     end
   end
 

--- a/spec/lib/xmldsig/signed_document_spec.rb
+++ b/spec/lib/xmldsig/signed_document_spec.rb
@@ -127,10 +127,31 @@ describe Xmldsig::SignedDocument do
     end
 
     context 'with inclusive namespaces for the signature' do
+      let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml, base64_strict_encode: true) }
       let(:unsigned_xml) { File.read("spec/fixtures/unsigned_signature_namespace.xml") }
       let(:signed_xml) { File.read("spec/fixtures/signed_signature_namespace.xml") }
 
       it 'canonicalizes and signs correctly' do
+        expect(unsigned_document.sign(private_key)).to eq(signed_xml)
+      end
+    end
+
+    context 'with base64 strict_encode enabled for the signature' do
+      let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml, base64_strict_encode: true) }
+      let(:unsigned_xml) { File.read("spec/fixtures/unsigned.xml") }
+      let(:signed_xml) { File.read("spec/fixtures/signed_with_base64_strict_encode_on.xml") }
+
+      it 'returns the signature with line breaks' do
+        expect(unsigned_document.sign(private_key)).to eq(signed_xml)
+      end
+    end
+
+    context 'with base64 strict encode disabled for the signature' do
+      let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml, base64_strict_encode: false) }
+      let(:unsigned_xml) { File.read("spec/fixtures/unsigned.xml") }
+      let(:signed_xml) { File.read("spec/fixtures/signed.xml") }
+
+      it 'returns the signature without with line breaks' do
         expect(unsigned_document.sign(private_key)).to eq(signed_xml)
       end
     end

--- a/spec/lib/xmldsig_spec.rb
+++ b/spec/lib/xmldsig_spec.rb
@@ -108,4 +108,52 @@ describe Xmldsig do
       end
     end
   end
+
+  describe "Allows specifying strict base64 encoding" do
+    context "an unsigned document with strict encoding" do
+      let(:unsigned_xml) { File.read("spec/fixtures/unsigned.xml") }
+      let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml, base64_strict_encode: true) }
+      let(:signed_document) { unsigned_document.sign(private_key) }
+
+      it "should be signable and validateable" do
+        expect(Xmldsig::SignedDocument.new(signed_document, base64_strict_encode: true).validate(certificate)).to eq(true)
+      end
+
+      it 'should have a signature element' do
+        expect(Xmldsig::SignedDocument.new(signed_document, base64_strict_encode: true).signatures.count).to eq(1)
+      end
+    end
+
+    context "a signed document with strict encoding" do
+      let(:signed_xml) { File.read("spec/fixtures/signed.xml") }
+      let(:signed_document) { Xmldsig::SignedDocument.new(signed_xml, base64_strict_encode: true) }
+
+      it "should be validateable" do
+        expect(signed_document.validate(certificate)).to eq(true)
+      end
+    end
+
+    context "an unsigned document with strict encoding off" do
+      let(:unsigned_xml) { File.read("spec/fixtures/unsigned.xml") }
+      let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml, base64_strict_encode: false) }
+      let(:signed_document) { unsigned_document.sign(private_key) }
+
+      it "should be signable and validateable" do
+        expect(Xmldsig::SignedDocument.new(signed_document, base64_strict_encode: false).validate(certificate)).to eq(true)
+      end
+
+      it 'should have a signature element' do
+        expect(Xmldsig::SignedDocument.new(signed_document, base64_strict_encode: false).signatures.count).to eq(1)
+      end
+    end
+
+    context "a signed document with strict encoding off" do
+      let(:signed_xml) { File.read("spec/fixtures/signed.xml") }
+      let(:signed_document) { Xmldsig::SignedDocument.new(signed_xml, base64_strict_encode: true) }
+
+      it "should be validateable" do
+        expect(signed_document.validate(certificate)).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Reverting enforcement of base64 strict encoding by default. I patched HEAD because we need the commit from https://github.com/spreedly/xmldsig/commit/73ce6216506e718f8dfc1e67165cc4a4ac2ade5c (>= v0.6.5) to fix PedidosYa. 

Older systems may use XML Signature libraries that adhere to base64
encodings specified by RFC 2045 (line breaks at least every 76 chars).
Newer systems may allow base64 encoding per RFC 4648 aka
'strict encoding', which eliminates the line break requirement. We can't
be entirely certain if our receivers support strict encoding or not so
we must support both options.

To support legacy receivers and systems that may require base64 encoding
with line breaks (RFC 2045), allow strict encoding to be turned on
or off.

Base64 strict encoding of the Signature and Digest value is turned off
by default.

ECS-103

Tests:

rspec ./spec/lib/xmldsig_spec.rb
37 examples, 0 failures